### PR TITLE
Fix incorrect parsing of Homebrew tar structure

### DIFF
--- a/lib/CrystalBuild/Downloader/Crystal.pm
+++ b/lib/CrystalBuild/Downloader/Crystal.pm
@@ -16,8 +16,8 @@ sub _detect_filename {
 sub _detect_extracted_dirs {
     my ($self, $cache_dir) = @_;
     my $matches = [
-        glob(File::Spec->join($cache_dir, 'crystal-lang/*')), # for Homebrew bottles
-        glob(File::Spec->join($cache_dir, 'crystal-*')),      # for GitHub releases
+        glob(File::Spec->join($cache_dir, 'crystal')),   # for Homebrew bottles
+        glob(File::Spec->join($cache_dir, 'crystal-*')), # for GitHub releases
     ];
     return grep { -d $_ } @$matches;
 }

--- a/lib/CrystalBuild/Installer/Crystal.pm
+++ b/lib/CrystalBuild/Installer/Crystal.pm
@@ -32,6 +32,12 @@ sub install {
         say "ok";
 
         print "Moving the Crystal directory ...";
+
+        # Homebrew's tarballs are structured differently
+        if ($tarball_url =~ /homebrew/) {
+            $extracted_dir = $extracted_dir . "/" . $crystal_version;
+        }
+
         $self->_move($extracted_dir, $install_dir);
         print "ok\n";
 


### PR DESCRIPTION
Github tarballs are structured:
  crystal-0.32.1/bin

Homebrew tarballs are structured:
  crystal/0.32.1/bin

This commit fixes the parsing of these different structures and ensures
that both can be handled properly.