### PR TITLE
Add v0.33.0 to releases

### DIFF
--- a/share/crystal-build/releases.json
+++ b/share/crystal-build/releases.json
@@ -1,5 +1,16 @@
 [
   {
+    "tag_name": "0.33.0",
+    "assets": {
+      "linux-x86": "https://github.com/crystal-lang/crystal/releases/download/0.33.0/crystal-0.33.0-1-linux-i686.tar.gz",
+      "linux-x64": "https://github.com/crystal-lang/crystal/releases/download/0.33.0/crystal-0.33.0-1-darwin-x86_64.tar.gz",
+      "darwin-x64": "https://github.com/crystal-lang/crystal/releases/download/0.33.0/crystal-0.33.0-1-linux-i686.tar.gz",
+      "darwin-x64-catalina": "https://homebrew.bintray.com/bottles/crystal-0.33.0.catalina.bottle.tar.gz",
+      "darwin-x64-mojave": "https://homebrew.bintray.com/bottles/crystal-0.33.0.mojave.bottle.tar.gz",
+      "darwin-x64-high_sierra": "https://homebrew.bintray.com/bottles/crystal-0.33.0.high_sierra.bottle.tar.gz"
+    }
+  },
+  {
     "tag_name": "0.32.1",
     "assets": {
       "linux-x86": "https://github.com/crystal-lang/crystal/releases/download/0.32.1/crystal-0.32.1-1-linux-i686.tar.gz",

--- a/share/crystal-build/shards.json
+++ b/share/crystal-build/shards.json
@@ -1,5 +1,6 @@
 {
   "default": "https://github.com/crystal-lang/shards/archive/master.tar.gz",
+  "0.33.0": "https://github.com/crystal-lang/shards/archive/v0.9.0.tar.gz",
   "0.32.1": "https://github.com/crystal-lang/shards/archive/v0.9.0.tar.gz",
   "0.32.0": "https://github.com/crystal-lang/shards/archive/v0.9.0.tar.gz",
   "0.31.1": "https://github.com/crystal-lang/shards/archive/v0.9.0.tar.gz",


### PR DESCRIPTION
v0.33.0 was recently released. This change adds the various Crystal tarballs to releases.json as well as the corresponding Shards tarball to shards.json.