### PR TITLE
Fix 0.33.0 OS/architecture links in releases.json

### DIFF
--- a/share/crystal-build/releases.json
+++ b/share/crystal-build/releases.json
@@ -3,8 +3,8 @@
     "tag_name": "0.33.0",
     "assets": {
       "linux-x86": "https://github.com/crystal-lang/crystal/releases/download/0.33.0/crystal-0.33.0-1-linux-i686.tar.gz",
-      "linux-x64": "https://github.com/crystal-lang/crystal/releases/download/0.33.0/crystal-0.33.0-1-darwin-x86_64.tar.gz",
-      "darwin-x64": "https://github.com/crystal-lang/crystal/releases/download/0.33.0/crystal-0.33.0-1-linux-i686.tar.gz",
+      "linux-x64": "https://github.com/crystal-lang/crystal/releases/download/0.33.0/crystal-0.33.0-1-linux-x86_64.tar.gz",
+      "darwin-x64": "https://github.com/crystal-lang/crystal/releases/download/0.33.0/crystal-0.33.0-1-darwin-x86_64.tar.gz",
       "darwin-x64-catalina": "https://homebrew.bintray.com/bottles/crystal-0.33.0.catalina.bottle.tar.gz",
       "darwin-x64-mojave": "https://homebrew.bintray.com/bottles/crystal-0.33.0.mojave.bottle.tar.gz",
       "darwin-x64-high_sierra": "https://homebrew.bintray.com/bottles/crystal-0.33.0.high_sierra.bottle.tar.gz"


### PR DESCRIPTION
Apparently I had put the OS/architecture links in the wrong place somehow. Stupid mistake. This fixes that.